### PR TITLE
fix batch embeddings above 32

### DIFF
--- a/langchain_predictionguard/PredictionGuardEmbeddings.py
+++ b/langchain_predictionguard/PredictionGuardEmbeddings.py
@@ -96,13 +96,6 @@ class PredictionGuardEmbeddings(BaseModel, Embeddings):
                         if emb['index'] == idx:
                             embeddings.append(emb['embedding'])
 
-        inputs = []
-        for text in texts:
-            input = {"text": text}
-            inputs.append(input)
-
-        response = self.client.embeddings.create(model=self.model, input=inputs)
-
         return embeddings
 
     def embed_query(self, text: str) -> List[float]:

--- a/langchain_predictionguard/PredictionGuardEmbeddings.py
+++ b/langchain_predictionguard/PredictionGuardEmbeddings.py
@@ -70,6 +70,32 @@ class PredictionGuardEmbeddings(BaseModel, Embeddings):
             Embeddings for the texts.
         """
 
+        max_batch_size = 30
+        embeddings = []
+        if len(texts) < max_batch_size:
+            response = self.client.embeddings.create(
+                model=self.model,
+                input=texts,
+                truncate=True
+            )
+            for idx in range(0, len(response["data"])):
+                for emb in response["data"]:
+                    if emb['index'] == idx:
+                        embeddings.append(emb['embedding'])
+        else:
+            smaller_batches = [texts[i:i+max_batch_size] for i in range(0, len(text), max_batch_size)]
+            embeddings = []
+            for smaller_batch in smaller_batches:
+                response = self.client.embeddings.create(
+                    model=self.model,
+                    input=smaller_batch,
+                    truncate=True
+                )
+                for idx in range(0, len(response["data"])):
+                    for emb in response["data"]:
+                        if emb['index'] == idx:
+                            embeddings.append(emb['embedding'])
+
         inputs = []
         for text in texts:
             input = {"text": text}
@@ -77,16 +103,7 @@ class PredictionGuardEmbeddings(BaseModel, Embeddings):
 
         response = self.client.embeddings.create(model=self.model, input=inputs)
 
-        res = []
-        indx = 0
-        for re in response["data"]:
-            if re["index"] == indx:
-                res.append(re["embedding"])
-                indx += 1
-            else:
-                continue
-
-        return res
+        return embeddings
 
     def embed_query(self, text: str) -> List[float]:
         """Call out to Prediction Guard's embedding endpoint for embedding query text.

--- a/langchain_predictionguard/PredictionGuardEmbeddings.py
+++ b/langchain_predictionguard/PredictionGuardEmbeddings.py
@@ -83,7 +83,7 @@ class PredictionGuardEmbeddings(BaseModel, Embeddings):
                     if emb['index'] == idx:
                         embeddings.append(emb['embedding'])
         else:
-            smaller_batches = [texts[i:i+max_batch_size] for i in range(0, len(text), max_batch_size)]
+            smaller_batches = [texts[i:i+max_batch_size] for i in range(0, len(texts), max_batch_size)]
             embeddings = []
             for smaller_batch in smaller_batches:
                 response = self.client.embeddings.create(


### PR DESCRIPTION
For LangFlow. We will need to rebuild. If more than 30 (or whatever `max_batch_size` is) documents are provided, it splits it up into multiple batches. 